### PR TITLE
hard code live remote setting server location

### DIFF
--- a/selenium-optmeowt-crawler/local-crawler.js
+++ b/selenium-optmeowt-crawler/local-crawler.js
@@ -37,6 +37,7 @@ async function setup() {
     .setBinary(firefox.Channel.NIGHTLY)
     .setBinary("/Applications/Firefox Nightly.app/Contents/MacOS/firefox")
     .setPreference("xpinstall.signatures.required", false)
+    .setPreference("services.settings.server", "https://firefox.settings.services.mozilla.com/v1")
     .addExtensions("./myextension.xpi");
 
   options.addArguments("--headful");


### PR DESCRIPTION
Fixes https://github.com/privacy-tech-lab/gpc-web-crawler/issues/122.

https://firefox-source-docs.mozilla.org/python/marionette_driver.html
I did two things:
1. I added https://github.com/mozilla/geckodriver to PATH.
2. I hard coded the "services.settings.server" preference (in about:config) to `https://firefox.settings.services.mozilla.com/v1"`.

to explain
1. I didn't see in the installation directions but did anyway to suppress the annoying warning that happens when you run the crawler.
2. Something is passing a development flag down to the web driver, which causes the "services.setting.server" key to have value "data:,#remote-settings-dummy/v1" in about:config. I do not know what causes the dummy url to be the default value of the key, all I presume is overriding it fixes the issue. 

With enough investigation we can stumble upon [this page](https://firefox-source-docs.mozilla.org/services/settings/index.html#inspect-local-data) which says:
<img width="886" alt="Screen Shot 2024-09-05 at 5 28 13 AM" src="https://github.com/user-attachments/assets/7d6b7b55-76c0-42f5-9095-685b096f361e">

If you open the browser developer tools in a normal nightly browser, and look at that exact portion of the indexedDB, you will notice that this is where all our anti-tracking lists are stored. 
<img width="833" alt="Screen Shot 2024-09-05 at 5 21 14 AM" src="https://github.com/user-attachments/assets/a45c4fa4-deed-415f-8322-a76e101042f7">
To motivate things more, this file is empty with in broken controlled browser.
<img width="936" alt="Screen Shot 2024-09-05 at 5 34 32 AM" src="https://github.com/user-attachments/assets/dd09fa3f-303a-4ef8-bf70-38e101804471">
If we look [elsewhere](https://firefox-source-docs.mozilla.org/services/settings/index.html#empty-local-database) on the same page, we learn this:
<img width="842" alt="Screen Shot 2024-09-05 at 4 53 34 AM" src="https://github.com/user-attachments/assets/cab6338f-7daf-47a5-9e87-f9b87f937024">

If you look at the console of the normal nightly, you'll see that it's very clean:
<img width="936" alt="Screen Shot 2024-09-05 at 5 40 15 AM" src="https://github.com/user-attachments/assets/ff4e2ba1-fdd0-49c6-8df6-caeec58f8a27">
But our controlled nightly instance has errors, conveniently for us in the RemoteSettingsClient:
<img width="1009" alt="Screen Shot 2024-09-05 at 5 42 06 AM" src="https://github.com/user-attachments/assets/53bdaad2-63a3-4f76-a39c-798ee5f8dc5e">
The error is especially useful to clue us in on what has happened. The local database is empty, so the client attempts to fetch settings from a sever, but fails since "**data:,#remote-settings-dummy/v1**" is not a real server. So, when we explicitly assign "services.settings.server" as "https://firefox.settings.services.mozilla.com/v1" in our preferences, we ensure that the local database gets synced with a real target.

With the change, our console looks nice again:
<img width="1009" alt="Screen Shot 2024-09-05 at 5 51 25 AM" src="https://github.com/user-attachments/assets/b405ccab-69e4-4a7e-8240-656d9ea0133f">

Moreover, the local database is flush, which is what we really care about:
<img width="1009" alt="Screen Shot 2024-09-05 at 5 51 55 AM" src="https://github.com/user-attachments/assets/dd463794-65bc-4def-a5bc-99fc9a32018b">



Analysis file:
[analysisfile.txt](https://github.com/user-attachments/files/16886411/analysisfile.txt)
screenshot of browser:
<img width="501" alt="Screen Shot 2024-09-05 at 4 39 19 AM" src="https://github.com/user-attachments/assets/1013a4ef-6c69-45b9-8867-bda7bf835ad2">

