### PR TITLE
Fixed merge conflicts from issue-98

### DIFF
--- a/scripts/rest_api.sh
+++ b/scripts/rest_api.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 cd /srv/analysis/rest_api
-echo "Running $0 in `pwd`"
+echo "Running $0 in `pwd` with argument: $1"
 
 set -e
 set -x
@@ -49,9 +49,16 @@ SQLCOMMANDS
 # Install dependencies for the REST API using npm
 npm install
 
-# Start the REST API using Node.js directly instead of systemd
-# This step replaces `systemctl` usage since Docker containers typically don't use systemd
-node index.js
+# Use the first argument to determine which mode to start
+echo "DEBUG_MODE is set to: '$DEBUG_MODE'"
+
+if [ "$DEBUG_MODE" = "true" ]; then
+  echo "Starting API in debug mode..."
+  node index.js debug
+else
+  echo "Starting API in normal mode..."
+  node index.js
+fi
 
 set +x
 echo '--------------------------------------------------'

--- a/scripts/start_container.sh
+++ b/scripts/start_container.sh
@@ -21,11 +21,23 @@ mkdir -p ./logs
 docker stop crawl_test || true
 docker rm crawl_test || true
 docker build --tag=crawl_test .  &> build.log
+
+# Check if the user provided the 'debug' argument
+if [[ "$1" == "debug" ]]; then
+  DEBUG_MODE="true"
+  echo "Starting container with debugging enabled."
+else
+  DEBUG_MODE="false"
+  echo "Starting container without debugging."
+fi
+
+# Run the Docker container with the DEBUG_MODE environment variable
 docker run -d --name crawl_test --privileged \
 	-v /sys/fs/cgroup:/sys/fs/cgroup:ro \
 	-v "$(pwd)":/srv/analysis \
 	-p 5901:5901 \
 	-p 6901:6901 \
 	-p 8080:8080 \
+	-e DEBUG_MODE=$DEBUG_MODE \
 	--user 0 \
 	crawl_test || true

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -2,7 +2,7 @@
 nodaemon=true
 
 [program:restapi]
-command=sh /srv/analysis/scripts/rest_api.sh 
+command=sh /srv/analysis/scripts/rest_api.sh ${DEBUG_MODE}
 stdout_logfile=/srv/analysis/logs/restapi.log
 stderr_logfile=/srv/analysis/logs/restapi.error.log
 autostart=true


### PR DESCRIPTION
Added functionality to the Docker setup that enables users to select between normal (sh scripts/start_container.sh) and debug modes (sh scripts/start_container.sh debug )when starting the crawler. Users can specify their preference via the command line, allowing the container to start the crawler with either standard logging or enhanced debug information for troubleshooting purposes. This provides flexibility for both routine operation and in-depth debugging as needed.