### PR TITLE
fix site_id issue

### DIFF
--- a/rest_api/index.js
+++ b/rest_api/index.js
@@ -73,7 +73,7 @@ class AnalysisAPI {
     this.app.get("/last_input_domain_analysis", this.getLastEntry.bind(this));
     this.app.get("/null_analysis", this.getNullEntries.bind(this));
     this.app.post("/analysis", this.createEntry.bind(this));
-    this.app.get("/analysis/:siteId", this.getEntryBySiteId.bind(this));
+    this.app.get("/analysis/:siteId/exists", this.hasEntryInDb.bind(this));
     this.app.put("/analysis", this.updateEntry.bind(this));
   }
 
@@ -159,13 +159,13 @@ class AnalysisAPI {
     }
   }
 
-  async getEntryBySiteId(req, res) {
+  async hasEntryInDb(req, res) {
     try {
       const results = await this.handleDatabaseQuery(
         "SELECT * FROM analysis.?? WHERE site_id = ?",
         [this.tableName, req.params.siteId]
       );
-      res.json(results);
+      res.json(results.length > 0);
     } catch (error) {
       this.handleError(res, error);
     }

--- a/rest_api/index.js
+++ b/rest_api/index.js
@@ -64,7 +64,7 @@ class AnalysisAPI {
       }
     });
 
-    this.app.get('/increment_siteId', async (req, res) => {
+    this.app.post('/increment_siteId', async (req, res) => {
         this.siteId += 1
         res.status(200).send('Site ID incremented');
     });

--- a/run-crawlers.sh
+++ b/run-crawlers.sh
@@ -7,20 +7,6 @@ run_crawler_batch() {
     local batch_id=$1
     TIMESTAMP=$(date +"%Y%m%d%H%M%S")
 
-    # Start the containers for this batch
-    DEBUG_MODE=$DEBUG_MODE TEST_CRAWL=false CRAWL_ID=$batch_id TIMESTAMP=$TIMESTAMP docker compose up --build -d
-
-    crawler_service="crawl_driver"
-    container_name=$(docker-compose ps -q -a $crawler_service)
-
-    echo "Started batch $batch_id with container $container_name (DEBUG_MODE=$DEBUG_MODE)"
-
-    # Wait for the crawler container to finish
-    while docker ps -q --no-trunc | grep -q "$container_name"; do
-        echo "Batch $batch_id still running..."
-        sleep 30
-    done
-
     echo "Batch $batch_id completed"
 }
 
@@ -29,16 +15,6 @@ run_crawler_custom() {
     # Start the containers for this batch
     DEBUG_MODE=true TEST_CRAWL=true TIMESTAMP=$TIMESTAMP docker compose up --build -d
 
-    crawler_service="crawl_driver"
-    container_name=$(docker-compose ps -q -a $crawler_service)
-
-    echo "Started custom batch with container $container_name (DEBUG_MODE=$DEBUG_MODE)"
-
-    # Wait for the crawler container to finish
-    while docker ps -q --no-trunc | grep -q "$container_name"; do
-        echo "Custom batch still running..."
-        sleep 30
-    done
 
     echo "Custom batch completed"
 }

--- a/selenium-optmeowt-crawler/DatabaseManager.js
+++ b/selenium-optmeowt-crawler/DatabaseManager.js
@@ -82,20 +82,29 @@ class DatabaseManager {
    */
   async checkAndUpdateDB(site, siteId) {
     try {
-      const response = await axios.get(`${API_BASE_URL}/analysis/${site}`);
+      const response = await axios.get(`${API_BASE_URL}/analysis/${siteId}`);
       const latestData = response.data;
+      console.log(`tried to check if ${siteId} was in database, result: ${latestData} `)
+      console.log(latestData.length)
       if (latestData.length >= 1) {
-        const lastEntry = latestData[latestData.length - 1];
-        if (lastEntry.site_id === null) {
-          lastEntry.site_id = siteId;
-          await this.updateSiteId(lastEntry);
-        }
         return true;
       } 
     } catch (error) {
       console.error('Database operation failed:', error.message);
     }
     return false;
+  }
+
+  /**
+   * Checks the database for existing analysis records for a given site and updates the site ID if necessary.
+   * Prioritizes updating existing entries where the site_id is null. If no such entry exists, it tries to update a null analysis entry.
+   * @async
+   * @param {string} site - The URL of the site.
+   * @param {number} siteId - The ID of the site to be updated in the database.
+   * @returns {Promise<boolean>} True if the database was updated, false otherwise.
+   */
+  async increment_siteId() {
+      await axios.get(`${API_BASE_URL}/increment_siteId`);
   }
 }
 

--- a/selenium-optmeowt-crawler/DatabaseManager.js
+++ b/selenium-optmeowt-crawler/DatabaseManager.js
@@ -15,24 +15,19 @@ class DatabaseManager {
   }
 
   /**
-   * Checks the database for existing analysis records for a given site and updates the site ID if necessary.
-   * Prioritizes updating existing entries where the site_id is null. If no such entry exists, it tries to update a null analysis entry.
+   * Checks the database for existing analysis records for a given siteId
    * @async
-   * @param {string} site - The URL of the site.
    * @param {number} siteId - The ID of the site to be updated in the database.
    * @returns {Promise<boolean>} True if the database was updated, false otherwise.
    */
-  async checkAndUpdateDB(siteId) {
+  async hasEntryInDb(siteId) {
     try {
-      const response = await axios.get(`${API_BASE_URL}/analysis/${siteId}`);
-      const latestData = response.data;
-      if (latestData.length >= 1) {
-        return true;
-      } 
+      const response = await axios.get(`${API_BASE_URL}/analysis/${siteId}/exists`);
+      return response.data === true
     } catch (error) {
       console.error('Database operation failed:', error.message);
+      return false;
     }
-    return false;
   }
 
   /**

--- a/selenium-optmeowt-crawler/DatabaseManager.js
+++ b/selenium-optmeowt-crawler/DatabaseManager.js
@@ -15,35 +15,6 @@ class DatabaseManager {
   }
 
   /**
-   * Updates the site ID for a given analysis record in the database.
-   * @async
-   * @param {object} data - The data object containing the analysis record to update.
-   */
-  async updateSiteId(data) {
-    try {
-      await axios.put(`${API_BASE_URL}/analysis`, data);
-    } catch (error) {
-      console.error('Error updating site ID:', error.message);
-    }
-  }
-
-  /**
-   * Logs the GPC endpoint check result to a CSV file.
-   * Also logs any errors associated with the GPC check.
-   * @async
-   * @param {string} site - The URL of the site being checked.
-   * @param {object} gpcResult - The result of the GPC endpoint check, including status and data.
-   */
-  async logGPCResult(site, gpcResult) {
-    const csvLine = `${site},${gpcResult?.status || 'None'},"${JSON.stringify(gpcResult?.data) || 'None'}"\n`;
-    await fs.promises.appendFile(`${this.crawl_path}/well-known-data.csv`, csvLine);
-
-    if (gpcResult?.error) {
-      await this.logError(site, gpcResult.error);
-    }
-  }
-
-  /**
    * Logs an error encountered during crawling or GPC endpoint checking to a JSON file.
    * @async
    * @param {string} site - The URL of the site where the error occurred.
@@ -103,7 +74,7 @@ class DatabaseManager {
    * @returns {Promise<void>} A promise that resolves when the siteId has been incremented.
    */
   async increment_siteId() {
-    await axios.get(`${API_BASE_URL}/increment_siteId`);
+    await axios.post(`${API_BASE_URL}/increment_siteId`);
   }
 }
 

--- a/selenium-optmeowt-crawler/DatabaseManager.js
+++ b/selenium-optmeowt-crawler/DatabaseManager.js
@@ -15,35 +15,6 @@ class DatabaseManager {
   }
 
   /**
-   * Logs an error encountered during crawling or GPC endpoint checking to a JSON file.
-   * @async
-   * @param {string} site - The URL of the site where the error occurred.
-   * @param {string} error - The error message.
-   */
-  async logError(site, error) {
-    const errors = await this.loadErrors();
-    errors[site] = error;
-    await fs.promises.writeFile(
-      `${this.crawl_path}/well-known-errors.json`,
-      JSON.stringify(errors, null, 2)
-    );
-  }
-
-  /**
-   * Loads previously logged errors from the JSON file.
-   * @async
-   * @returns {Promise<object>} An object containing the logged errors, keyed by site URL.
-   */
-  async loadErrors() {
-    try {
-      const data = await fs.promises.readFile(`${this.crawl_path}/well-known-errors.json`, 'utf8');
-      return JSON.parse(data);
-    } catch {
-      return {};
-    }
-  }
-
-  /**
    * Checks the database for existing analysis records for a given site and updates the site ID if necessary.
    * Prioritizes updating existing entries where the site_id is null. If no such entry exists, it tries to update a null analysis entry.
    * @async
@@ -51,12 +22,10 @@ class DatabaseManager {
    * @param {number} siteId - The ID of the site to be updated in the database.
    * @returns {Promise<boolean>} True if the database was updated, false otherwise.
    */
-  async checkAndUpdateDB(site, siteId) {
+  async checkAndUpdateDB(siteId) {
     try {
       const response = await axios.get(`${API_BASE_URL}/analysis/${siteId}`);
       const latestData = response.data;
-      console.log(`tried to check if ${siteId} was in database, result: ${latestData} `)
-      console.log(latestData.length)
       if (latestData.length >= 1) {
         return true;
       } 

--- a/selenium-optmeowt-crawler/DatabaseManager.js
+++ b/selenium-optmeowt-crawler/DatabaseManager.js
@@ -96,15 +96,14 @@ class DatabaseManager {
   }
 
   /**
-   * Checks the database for existing analysis records for a given site and updates the site ID if necessary.
-   * Prioritizes updating existing entries where the site_id is null. If no such entry exists, it tries to update a null analysis entry.
-   * @async
-   * @param {string} site - The URL of the site.
-   * @param {number} siteId - The ID of the site to be updated in the database.
-   * @returns {Promise<boolean>} True if the database was updated, false otherwise.
+   * Increments the siteId variable by sending a GET request to the REST API.
+   *
+   * This method calls the `/increment_siteId` endpoint, which increments the siteId value on the server.
+   *
+   * @returns {Promise<void>} A promise that resolves when the siteId has been incremented.
    */
   async increment_siteId() {
-      await axios.get(`${API_BASE_URL}/increment_siteId`);
+    await axios.get(`${API_BASE_URL}/increment_siteId`);
   }
 }
 

--- a/selenium-optmeowt-crawler/WebCrawler.js
+++ b/selenium-optmeowt-crawler/WebCrawler.js
@@ -19,8 +19,6 @@ class WebCrawler {
       this.config = new CrawlerConfig(args);
       this.browserManager = new BrowserManager(this.config);
       this.dbManager = new DatabaseManager(this.config.save_path);
-    
-
     }
   
     getSitePath() {
@@ -107,6 +105,7 @@ class WebCrawler {
         }
       }
       const wasAdded = await this.dbManager.checkAndUpdateDB(site, siteId);
+      console.log(wasAdded)
       if (wasAdded){
          return 'success';
       }else if(retries > 0){
@@ -169,9 +168,9 @@ class WebCrawler {
      * @returns {Promise<object>} An object containing the crawl status and GPC data.
      */
     async crawlSite(site, siteId) {
-
+      console.log(`before`)
       const visitResult = await this.visitSiteWithRetries(site, siteId, 1)
-
+      console.log(`after`)
   
       return {
         site,
@@ -188,15 +187,13 @@ class WebCrawler {
       await this.loadSites();
       await this.browserManager.setup();
       for (let siteId in this.config.sites) {
-        const originalUrl = this.config.sites[siteId]
-        
-        const finalUrl = await this.checkRedirect(originalUrl)
-  
+        const url = this.config.sites[siteId]
+        const { hostname } = new URL(url);
+
         const startTime = Date.now();
-        const { hostname } = new URL(finalUrl);
         console.log('Processing:', hostname);
         const result = await this.crawlSite(hostname, siteId);
-  
+        await this.dbManager.increment_siteId()
         const timeSpent = (Date.now() - startTime) / 1000;
         console.log(
           `Site: ${hostname}`,

--- a/selenium-optmeowt-crawler/WebCrawler.js
+++ b/selenium-optmeowt-crawler/WebCrawler.js
@@ -152,7 +152,7 @@ class WebCrawler {
         const timeSpent = (Date.now() - startTime) / 1000;
         console.log(
           `Site: ${hostname}`,
-          `Site ID: ${siteID}`,
+          `Site ID: ${siteId}`,
           `Crawl: ${result.crawlSuccess ? 'Success' : 'Failed'}`,
           `Time: ${timeSpent}s`
         );

--- a/selenium-optmeowt-crawler/WebCrawler.js
+++ b/selenium-optmeowt-crawler/WebCrawler.js
@@ -105,7 +105,6 @@ class WebCrawler {
         }
       }
       const wasAdded = await this.dbManager.checkAndUpdateDB(site, siteId);
-      console.log(wasAdded)
       if (wasAdded){
          return 'success';
       }else if(retries > 0){
@@ -113,21 +112,7 @@ class WebCrawler {
       }else{
          return 'failure'
       }
-    }
-  
-    async checkRedirect(url) {
-      try {
-        const response = await axios.get(url);
-        return response.request.res.responseUrl || url;
-      } catch (error) {
-        if (error.response && error.response.request.res.responseUrl) {
-          return error.response.request.res.responseUrl;
-        }
-        console.error('Error checking redirect:', error.message);
-        return url; // Return the original URL if there's an error
-      }
-    }
-    
+    }    
     
     /**
      * Handles errors encountered during crawling, logs the error, and takes a screenshot if applicable.
@@ -168,9 +153,7 @@ class WebCrawler {
      * @returns {Promise<object>} An object containing the crawl status and GPC data.
      */
     async crawlSite(site, siteId) {
-      console.log(`before`)
       const visitResult = await this.visitSiteWithRetries(site, siteId, 1)
-      console.log(`after`)
   
       return {
         site,

--- a/selenium-optmeowt-crawler/WebCrawler.js
+++ b/selenium-optmeowt-crawler/WebCrawler.js
@@ -43,34 +43,6 @@ class WebCrawler {
       });
     }
   
-    /**
-     * Checks for the presence of a GPC endpoint (gpc.json) on a given site.
-     * @async
-     * @param {string} site - The base URL of the site to check.
-     * @returns {Promise<object>} An object containing the status and data of the GPC endpoint check.
-     */
-    async checkGPCEndpoint(site, retries = 0) {
-      const gpcUrl = new URL('/.well-known/gpc.json', site)
-      try {
-        const response = await axios.get(gpcUrl, {
-          timeout: PAGE_LOAD_TIMEOUT
-	});
-        return {
-          status: response.status,
-          data: response.status === 200 ? response.data : null
-        };
-      } catch (error) {
-          if (retries > 0){
-            return this.checkGPCEndpoint(site, retries - 1);
-          }else {
-            return {
-                  status: null,
-                  data: null,
-                  error: error.message
-                };
-          }
-      }
-    }
   
     /**
      * Visits a site using the browser, with retry logic for recoverable errors.

--- a/selenium-optmeowt-crawler/WebCrawler.js
+++ b/selenium-optmeowt-crawler/WebCrawler.js
@@ -121,7 +121,7 @@ class WebCrawler {
      * @param {string} site - The URL of the site where the error occurred.
      */
     async handleError(error, site) {
-      this.config.errors[error.name] = site;
+      (this.config.errors[error.name] ??= []).push(site);
       await fs.promises.writeFile(
         `${this.config.save_path}/error-logging/error-logging.json`,
         JSON.stringify(this.config.errors)

--- a/selenium-optmeowt-crawler/WebCrawler.js
+++ b/selenium-optmeowt-crawler/WebCrawler.js
@@ -145,12 +145,12 @@ class WebCrawler {
     }
   
     /**
-     * Crawls a single site, including visiting the site and checking for the GPC endpoint.
-     * It also updates the database with the crawl and GPC check results.
+     * Crawls a single site,.
+     * It also updates the database with the crawl results.
      * @async
      * @param {string} site - The hostname of the site to crawl.
      * @param {number} siteId - The ID of the site in the crawl list.
-     * @returns {Promise<object>} An object containing the crawl status and GPC data.
+     * @returns {Promise<object>} An object containing the crawl status.
      */
     async crawlSite(site, siteId) {
       const visitResult = await this.visitSiteWithRetries(site, siteId, 1)

--- a/selenium-optmeowt-crawler/WebCrawler.js
+++ b/selenium-optmeowt-crawler/WebCrawler.js
@@ -55,7 +55,7 @@ class WebCrawler {
     async visitSiteWithRetries(site, siteId, retries = 0) {
       //Checks if a site has been added to database
       //Always false on first try of a site
-      const alreadyAdded = await this.dbManager.checkAndUpdateDB(site, siteId);
+      const alreadyAdded = await this.dbManager.hasEntryInDb(siteId);
       if (!alreadyAdded){
         try {
           await this.browserManager.driver.get(this.config.sites[siteId]);
@@ -76,7 +76,7 @@ class WebCrawler {
           }
         }
       }
-      const wasAdded = await this.dbManager.checkAndUpdateDB(site, siteId);
+      const wasAdded = await this.dbManager.hasEntryInDb(siteId);
       if (wasAdded){
          return 'success';
       }else if(retries > 0){
@@ -152,6 +152,7 @@ class WebCrawler {
         const timeSpent = (Date.now() - startTime) / 1000;
         console.log(
           `Site: ${hostname}`,
+          `Site ID: ${siteID}`,
           `Crawl: ${result.crawlSuccess ? 'Success' : 'Failed'}`,
           `Time: ${timeSpent}s`
         );


### PR DESCRIPTION
- Introduced an in-memory siteId and added a new endpoint (POST /increment_siteId) to increment it.

- Changed the GET endpoint from /analysis/:domain to /analysis/:siteId/exists and renamed the corresponding method to hasEntryInDb, now returning a boolean.

- Updated createEntry to assign site_id from the in-memory variable.

- Removed deprecated code and improved logging for clarity.