### PR TITLE
Change RestAPI to use updated Node image

### DIFF
--- a/rest_api/Dockerfile
+++ b/rest_api/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16
+FROM node:18
 
 WORKDIR /srv/analysis/rest_api
 


### PR DESCRIPTION
The old version of Node relied on a version of Debian that has since been archived, leading to errors when setting up the crawler on a new computer. Updating to a slightly newer Node image fixed this issue.