### PR TITLE
Update analysis.js

### DIFF
--- a/gpc-analysis-extension/src/background/analysis/analysis.js
+++ b/gpc-analysis-extension/src/background/analysis/analysis.js
@@ -266,7 +266,7 @@ async function fetchUSPStringData() {
 //sends sql post request to db and then resets the global sql_data
 function send_sql_and_reset(domain) {
   analysis_userend[domain]["domain"] = domain;
-  analysis_userend[domain]["urlClassification"] = JSON.stringify(urlclassification[domain]).slice(0, 5000); //add urlClassification info, cap it at 5000 chars 
+  analysis_userend[domain]["urlClassification"] = JSON.stringify(urlclassification[domain]).slice(0, 50000); //add urlClassification info, cap it at 5000 chars 
   axios
     .post("http://rest_api:8080/analysis", analysis_userend[domain], {
       headers: {


### PR DESCRIPTION
Preventing truncation of URL classifications for future crawls by now slicing at the google sheets character cell limit of 50,000 characters rather than 5000 characters.