### PR TITLE
Fix Dependabot to group minor/patch updates from non-root directories 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,47 @@
 version: 2
 updates:
+  # 1. The Root Directory
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
     groups:
-      crawler-minor-and-patch:
+      crawler-root-minor-and-patch:
         update-types:
           - minor
           - patch
-      crawler-major:
+      crawler-root-major:
+        update-types:
+          - major
+
+  # 2. The Analysis Extension Directory
+  - package-ecosystem: npm
+    directory: /gpc-analysis-extension
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      crawler-analysis-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+      crawler-analysis-major:
+        update-types:
+          - major
+
+  # 3. The Crawler Directory
+  - package-ecosystem: npm
+    directory: /selenium-optmeowt-crawler
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      crawler-selenium-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+      crawler-selenium-major:
         update-types:
           - major
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -18,7 +18,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Approve and enable auto-merge for patch and minor updates
-        if: steps.metadata.outputs.dependency-group == 'crawler-minor-and-patch'
+        if: endsWith(steps.metadata.outputs.dependency-group, '-minor-and-patch')
         run: |
           gh pr review --approve "$PR_URL"
           gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
Created two more groups for updates that don't come from the root directory. 

Previously, dependabot was only grouping the updates that came the root manifest (package.json). However, there are other manifests within sub folders that needed accounting for. This PR adds those new groups and updates the auto-merge workflow slightly to accommodate all of them.