### PR TITLE
Add security groups for  & optimized by grouping across directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,12 +20,12 @@ updates:
 
       # Groups for Security Updates
       crawler-security-minor-and-patch:
-        applies-to: securtiy-updates
+        applies-to: security-updates
         update-types:
           - minor
           - patch
       crawler-security-major:
-        applies-to: securtiy-updates
+        applies-to: security-updates
         update-types:
           - major
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,47 +1,31 @@
 version: 2
 updates:
-  # 1. The Root Directory
   - package-ecosystem: npm
-    directory: /
+    directories:
+      - "/"
+      - "/gpc-analysis-extension"
+      - "/selenium-optmeowt-crawler"
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
     groups:
-      crawler-root-minor-and-patch:
+      # Groups for Version Updates
+      crawler-minor-and-patch:
         update-types:
           - minor
           - patch
-      crawler-root-major:
+      crawler-major:
         update-types:
           - major
 
-  # 2. The Analysis Extension Directory
-  - package-ecosystem: npm
-    directory: /gpc-analysis-extension
-    schedule:
-      interval: weekly
-    open-pull-requests-limit: 10
-    groups:
-      crawler-analysis-minor-and-patch:
+      # Groups for Security Updates
+      crawler-security-minor-and-patch:
+        applies-to: securtiy-updates
         update-types:
           - minor
           - patch
-      crawler-analysis-major:
-        update-types:
-          - major
-
-  # 3. The Crawler Directory
-  - package-ecosystem: npm
-    directory: /selenium-optmeowt-crawler
-    schedule:
-      interval: weekly
-    open-pull-requests-limit: 10
-    groups:
-      crawler-selenium-minor-and-patch:
-        update-types:
-          - minor
-          - patch
-      crawler-selenium-major:
+      crawler-security-major:
+        applies-to: securtiy-updates
         update-types:
           - major
 


### PR DESCRIPTION
Added new groups for security updates. Auto merge was already configured correctly, so no changes there.

Earlier this week, an issue was noticed where some updates were not properly grouped. The fix was to give each directory with a manifest (package.json file) its own `major` group & `minor-patch` group. This resulted in 6 total groups (three total manifests, with two groups each) which worked, but was a but overkill. This PR optimizes it by grouping across directories, which is a feature of dependabot I discovered on [this documentation page](https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/optimizing-pr-creation-version-updates#grouping-updates-across-directories-in-a-monorepo). In short the previous verbose solution has now been optimized. 

See the https://github.com/privacy-tech-lab/gpc-optmeowt/pull/593 for more info on the security updates.