### PR TITLE
Fix inconsistent merge paths (#287)

### DIFF
--- a/merge_well_known_data.sh
+++ b/merge_well_known_data.sh
@@ -10,7 +10,7 @@ rm -f "$output"
 mkdir crawl_results/well-known
 
 # Copy pt1 the output file
-cat crawl_results/pt1/well-known-data.csv >> $output
+cat crawl_results/pt1/Extra/well-known-data.csv >> $output
 
 # Append pt2 to pt8 
 for i in {2..8}

--- a/merge_well_known_data.sh
+++ b/merge_well_known_data.sh
@@ -7,7 +7,7 @@ output="crawl_results/well-known/well-known-data.csv"
 rm -f "$output"
 
 #makes well-known directory
-mkdir crawl_results/well-known
+mkdir crawl_results/well-known -p
 
 # Copy pt1 the output file
 cat crawl_results/pt1/Extra/well-known-data.csv >> $output
@@ -18,4 +18,4 @@ do
     tail -n +0 crawl_results/pt${i}/Extra/well-known-data.csv >> $output
 done
 
-echo "Files have been merged into crawl_results/merged-well-known-data.csv"
+echo "Files have been merged into crawl_results/well-known/merged-well-known-data.csv"

--- a/merge_well_known_data.sh
+++ b/merge_well_known_data.sh
@@ -7,7 +7,7 @@ output="crawl_results/well-known/well-known-data.csv"
 rm -f "$output"
 
 #makes well-known directory
-mkdir crawl_results/well-known -p
+mkdir -p crawl_results/well-known
 
 # Copy pt1 the output file
 cat crawl_results/pt1/Extra/well-known-data.csv >> $output
@@ -18,4 +18,4 @@ do
     tail -n +0 crawl_results/pt${i}/Extra/well-known-data.csv >> $output
 done
 
-echo "Files have been merged into crawl_results/well-known/merged-well-known-data.csv"
+echo "Files have been merged into crawl_results/well-known/well-known-data.csv"

--- a/well-known-crawl/well-known-crawl.py
+++ b/well-known-crawl/well-known-crawl.py
@@ -47,9 +47,10 @@ full_ts = time.time()
 
 
 if TEST_CRAWL == "true":
-    save_path = f"./crawl_results/CUSTOMCRAWL-{TIMESTAMP}"
+    save_path = f"./crawl_results/CUSTOMCRAWL-{TIMESTAMP}/Extra"
 else:
-    save_path = f"./crawl_results/pt{CRAWL_ID}"
+    save_path = f"./crawl_results/pt{CRAWL_ID}/Extra"
+os.makedirs(save_path, exist_ok=True)
 data_save_path = save_path + "/well-known-data.csv"
 error_save_path = save_path + "/well-known-errors.json"
 with open(data_save_path, "a") as f:


### PR DESCRIPTION
Changes path variables to fix inconsistency in `merge-well-known-data.sh`

The main bug pointed out in #287 was that pt1's `well-known-data` was hard coded to reference a different directory from parts 2-8. This PR solves that inconsistency by standardizing all well-known-data to be located at `crawl_results/pt{ID}/Extra/well-known-data.csv`.

To that end `well-known-crawl.py` was modified to automatically create the `Extra` directory. Since this is something we used to do manually, I'll modify the wiki accordingly.